### PR TITLE
Ensure all checkboxes are actionable tasks

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,12 +4,6 @@ Please include a summary of the changes and the related issue. Please also inclu
 
 Fixes (issue, e.g. ABC-1)
 
-## Type of change
-<!-- Keep any that apply -->
-- Bug fix (non-breaking change which fixes an issue)
-- New feature (non-breaking change which adds functionality)
-- Breaking change (fix or feature that would cause existing functionality to not work as expected)
-
 ### If this change requires new or updated documentation, provide a link below:
 
 
@@ -28,5 +22,6 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 
 # ✅ Checklist:
 
+- [ ] I have added a label describing the type of change (such as https://github.com/vault-innovation/.github/labels/bug or https://github.com/vault-innovation/.github/labels/enhancement)
 - [ ] I have performed a self-review of my code
 - [ ] I have added tests that prove my fix is effective or that my feature works

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,10 +5,10 @@ Please include a summary of the changes and the related issue. Please also inclu
 Fixes (issue, e.g. ABC-1)
 
 ## Type of change
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+<!-- Keep any that apply -->
+- Bug fix (non-breaking change which fixes an issue)
+- New feature (non-breaking change which adds functionality)
+- Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
 ### If this change requires new or updated documentation, provide a link below:
 


### PR DESCRIPTION
# 📖 Description

This is a minor issue but it's been bugging me when working with pull requests. Github assumes that any checkboxes in your PR are action items or tasks, and in certain parts of the UI will display the percent of tasks that are done - 

<img alt="screenshot" src="https://github.com/user-attachments/assets/00e15396-16b4-4242-9da6-5e3b96db13c6">

In this example it's because only one of the "tasks" in "Type of Change" is checked. 

## Option A - Text
This PR removes the checkboxes and instead suggests that the user delete any that don't apply, which is quick to do.

```markdown
<!-- Keep any that apply -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
```

## Option B - Emojis
Another option might be putting an emoji check near the option chosen, such as - 

> - ✅ Bug fix (non-breaking change which fixes an issue)
> - New feature (non-breaking change which adds functionality)
> - Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Option C - Labels
It would also be possible to use the label system in GitHub -

<img width="329" alt="label adding" src="https://github.com/user-attachments/assets/c877b6c3-3a26-4be8-a041-76f6e6beba8b">

And change it to a checklist item such as - 

> - [x] I have added a label describing the type of change (such as https://github.com/vault-innovation/.github/labels/bug or https://github.com/vault-innovation/.github/labels/enhancement)

This then also have the benefit of showing this information in the PR list
<img width="809" alt="labels" src="https://github.com/user-attachments/assets/6b3cecb0-e90c-44ad-93d5-a45cb887b287">
